### PR TITLE
MoveIt configs still use Pr2MoveItControllerManager

### DIFF
--- a/fanuc_lrmate200ic5h_moveit_config/config/controllers.yaml
+++ b/fanuc_lrmate200ic5h_moveit_config/config/controllers.yaml
@@ -1,6 +1,5 @@
-controller_manager_ns: pr2_controller_manager
 controller_list:
   - name: ""
-    ns: joint_trajectory_action
-    default: true
+    action_ns: joint_trajectory_action
+    type: FollowJointTrajectory
     joints: [joint_1, joint_2, joint_3, joint_4, joint_5]

--- a/fanuc_lrmate200ic5h_moveit_config/launch/fanuc_lrmate200ic5h_moveit_controller_manager.launch
+++ b/fanuc_lrmate200ic5h_moveit_config/launch/fanuc_lrmate200ic5h_moveit_controller_manager.launch
@@ -1,14 +1,7 @@
 <launch>
 
-  <arg name="moveit_controller_manager" default="pr2_moveit_controller_manager/Pr2MoveItControllerManager"/>
-
+  <arg name="moveit_controller_manager" default="moveit_simple_controller_manager/MoveItSimpleControllerManager"/>
   <param name="moveit_controller_manager" value="$(arg moveit_controller_manager)"/>
-
-  <arg name="controller_manager_name" default="pr2_controller_manager" />
-  <param name="controller_manager_name" value="$(arg controller_manager_name)"/>
-
-  <arg name="use_controller_manager" default="false" />
-  <param name="use_controller_manager" value="$(arg use_controller_manager)" />
 
   <rosparam file="$(find fanuc_lrmate200ic5h_moveit_config)/config/controllers.yaml"/>
 

--- a/fanuc_lrmate200ic5h_moveit_config/package.xml
+++ b/fanuc_lrmate200ic5h_moveit_config/package.xml
@@ -27,4 +27,5 @@
   <run_depend>moveit_ros_move_group</run_depend>
   <run_depend>xacro</run_depend>
   <run_depend>fanuc_lrmate200ic_support</run_depend>
+  <run_depend>moveit_simple_controller_manager</run_depend>
 </package>

--- a/fanuc_lrmate200ic_moveit_config/config/controllers.yaml
+++ b/fanuc_lrmate200ic_moveit_config/config/controllers.yaml
@@ -1,6 +1,5 @@
-controller_manager_ns: pr2_controller_manager
 controller_list:
   - name: ""
-    ns: joint_trajectory_action
-    default: true
+    action_ns: joint_trajectory_action
+    type: FollowJointTrajectory
     joints: [joint_1, joint_2, joint_3, joint_4, joint_5, joint_6]

--- a/fanuc_lrmate200ic_moveit_config/launch/fanuc_lrmate200ic_moveit_controller_manager.launch
+++ b/fanuc_lrmate200ic_moveit_config/launch/fanuc_lrmate200ic_moveit_controller_manager.launch
@@ -1,14 +1,7 @@
 <launch>
 
-  <arg name="moveit_controller_manager" default="pr2_moveit_controller_manager/Pr2MoveItControllerManager"/>
-
+  <arg name="moveit_controller_manager" default="moveit_simple_controller_manager/MoveItSimpleControllerManager"/>
   <param name="moveit_controller_manager" value="$(arg moveit_controller_manager)"/>
-
-  <arg name="controller_manager_name" default="pr2_controller_manager" />
-  <param name="controller_manager_name" value="$(arg controller_manager_name)"/>
-
-  <arg name="use_controller_manager" default="false" />
-  <param name="use_controller_manager" value="$(arg use_controller_manager)" />
 
   <rosparam file="$(find fanuc_lrmate200ic_moveit_config)/config/controllers.yaml"/>
 

--- a/fanuc_lrmate200ic_moveit_config/package.xml
+++ b/fanuc_lrmate200ic_moveit_config/package.xml
@@ -27,4 +27,5 @@
   <run_depend>moveit_ros_move_group</run_depend>
   <run_depend>xacro</run_depend>
   <run_depend>fanuc_lrmate200ic_support</run_depend>
+  <run_depend>moveit_simple_controller_manager</run_depend>
 </package>

--- a/fanuc_m10ia_moveit_config/config/controllers.yaml
+++ b/fanuc_m10ia_moveit_config/config/controllers.yaml
@@ -1,6 +1,5 @@
-controller_manager_ns: pr2_controller_manager
 controller_list:
   - name: ""
-    ns: joint_trajectory_action
-    default: true
+    action_ns: joint_trajectory_action
+    type: FollowJointTrajectory
     joints: [joint_1, joint_2, joint_3, joint_4, joint_5, joint_6]

--- a/fanuc_m10ia_moveit_config/launch/fanuc_m10ia_moveit_controller_manager.launch
+++ b/fanuc_m10ia_moveit_config/launch/fanuc_m10ia_moveit_controller_manager.launch
@@ -1,14 +1,7 @@
 <launch>
 
-  <arg name="moveit_controller_manager" default="pr2_moveit_controller_manager/Pr2MoveItControllerManager"/>
-
+  <arg name="moveit_controller_manager" default="moveit_simple_controller_manager/MoveItSimpleControllerManager"/>
   <param name="moveit_controller_manager" value="$(arg moveit_controller_manager)"/>
-
-  <arg name="controller_manager_name" default="pr2_controller_manager" />
-  <param name="controller_manager_name" value="$(arg controller_manager_name)"/>
-
-  <arg name="use_controller_manager" default="false" />
-  <param name="use_controller_manager" value="$(arg use_controller_manager)" />
 
   <rosparam file="$(find fanuc_m10ia_moveit_config)/config/controllers.yaml"/>
 

--- a/fanuc_m10ia_moveit_config/package.xml
+++ b/fanuc_m10ia_moveit_config/package.xml
@@ -27,4 +27,5 @@
   <run_depend>moveit_ros_move_group</run_depend>
   <run_depend>xacro</run_depend>
   <run_depend>fanuc_m10ia_support</run_depend>
+  <run_depend>moveit_simple_controller_manager</run_depend>
 </package>

--- a/fanuc_m16ib20_moveit_config/config/controllers.yaml
+++ b/fanuc_m16ib20_moveit_config/config/controllers.yaml
@@ -1,6 +1,5 @@
-controller_manager_ns: pr2_controller_manager
 controller_list:
   - name: ""
-    ns: joint_trajectory_action
-    default: true
+    action_ns: joint_trajectory_action
+    type: FollowJointTrajectory
     joints: [joint_1, joint_2, joint_3, joint_4, joint_5, joint_6]

--- a/fanuc_m16ib20_moveit_config/launch/fanuc_m16ib20_moveit_controller_manager.launch
+++ b/fanuc_m16ib20_moveit_config/launch/fanuc_m16ib20_moveit_controller_manager.launch
@@ -1,14 +1,7 @@
 <launch>
 
-  <arg name="moveit_controller_manager" default="pr2_moveit_controller_manager/Pr2MoveItControllerManager"/>
-
+  <arg name="moveit_controller_manager" default="moveit_simple_controller_manager/MoveItSimpleControllerManager"/>
   <param name="moveit_controller_manager" value="$(arg moveit_controller_manager)"/>
-
-  <arg name="controller_manager_name" default="pr2_controller_manager" />
-  <param name="controller_manager_name" value="$(arg controller_manager_name)"/>
-
-  <arg name="use_controller_manager" default="false" />
-  <param name="use_controller_manager" value="$(arg use_controller_manager)" />
 
   <rosparam file="$(find fanuc_m16ib20_moveit_config)/config/controllers.yaml"/>
 

--- a/fanuc_m16ib20_moveit_config/package.xml
+++ b/fanuc_m16ib20_moveit_config/package.xml
@@ -27,4 +27,5 @@
   <run_depend>moveit_ros_move_group</run_depend>
   <run_depend>xacro</run_depend>
   <run_depend>fanuc_m16ib_support</run_depend>
+  <run_depend>moveit_simple_controller_manager</run_depend>
 </package>

--- a/fanuc_m430ia2f_moveit_config/config/controllers.yaml
+++ b/fanuc_m430ia2f_moveit_config/config/controllers.yaml
@@ -1,6 +1,5 @@
-controller_manager_ns: pr2_controller_manager
 controller_list:
   - name: ""
-    ns: joint_trajectory_action
-    default: true
+    action_ns: joint_trajectory_action
+    type: FollowJointTrajectory
     joints: [joint_1, joint_2, joint_3, joint_4, joint_5]

--- a/fanuc_m430ia2f_moveit_config/launch/fanuc_m430ia2f_moveit_controller_manager.launch
+++ b/fanuc_m430ia2f_moveit_config/launch/fanuc_m430ia2f_moveit_controller_manager.launch
@@ -1,14 +1,7 @@
 <launch>
 
-  <arg name="moveit_controller_manager" default="pr2_moveit_controller_manager/Pr2MoveItControllerManager"/>
-
+  <arg name="moveit_controller_manager" default="moveit_simple_controller_manager/MoveItSimpleControllerManager"/>
   <param name="moveit_controller_manager" value="$(arg moveit_controller_manager)"/>
-
-  <arg name="controller_manager_name" default="pr2_controller_manager" />
-  <param name="controller_manager_name" value="$(arg controller_manager_name)"/>
-
-  <arg name="use_controller_manager" default="false" />
-  <param name="use_controller_manager" value="$(arg use_controller_manager)" />
 
   <rosparam file="$(find fanuc_m430ia2f_moveit_config)/config/controllers.yaml"/>
 

--- a/fanuc_m430ia2f_moveit_config/package.xml
+++ b/fanuc_m430ia2f_moveit_config/package.xml
@@ -27,4 +27,5 @@
   <run_depend>moveit_ros_move_group</run_depend>
   <run_depend>xacro</run_depend>
   <run_depend>fanuc_m430ia_support</run_depend>
+  <run_depend>moveit_simple_controller_manager</run_depend>
 </package>

--- a/fanuc_m430ia2p_moveit_config/config/controllers.yaml
+++ b/fanuc_m430ia2p_moveit_config/config/controllers.yaml
@@ -1,6 +1,5 @@
-controller_manager_ns: pr2_controller_manager
 controller_list:
   - name: ""
-    ns: joint_trajectory_action
-    default: true
+    action_ns: joint_trajectory_action
+    type: FollowJointTrajectory
     joints: [joint_1, joint_2, joint_3, joint_4, joint_5, joint_6]

--- a/fanuc_m430ia2p_moveit_config/launch/fanuc_m430ia2p_moveit_controller_manager.launch
+++ b/fanuc_m430ia2p_moveit_config/launch/fanuc_m430ia2p_moveit_controller_manager.launch
@@ -1,14 +1,7 @@
 <launch>
 
-  <arg name="moveit_controller_manager" default="pr2_moveit_controller_manager/Pr2MoveItControllerManager"/>
-
+  <arg name="moveit_controller_manager" default="moveit_simple_controller_manager/MoveItSimpleControllerManager"/>
   <param name="moveit_controller_manager" value="$(arg moveit_controller_manager)"/>
-
-  <arg name="controller_manager_name" default="pr2_controller_manager" />
-  <param name="controller_manager_name" value="$(arg controller_manager_name)"/>
-
-  <arg name="use_controller_manager" default="false" />
-  <param name="use_controller_manager" value="$(arg use_controller_manager)" />
 
   <rosparam file="$(find fanuc_m430ia2p_moveit_config)/config/controllers.yaml"/>
 

--- a/fanuc_m430ia2p_moveit_config/package.xml
+++ b/fanuc_m430ia2p_moveit_config/package.xml
@@ -27,4 +27,5 @@
   <run_depend>moveit_ros_move_group</run_depend>
   <run_depend>xacro</run_depend>
   <run_depend>fanuc_m430ia_support</run_depend>
+  <run_depend>moveit_simple_controller_manager</run_depend>
 </package>


### PR DESCRIPTION
Should be migrated to `MoveItSimpleControllerManager`.

See also ros-industrial/industrial_core#3.
