### PR TITLE
Use in-order processing in all xacro loading launch files

### DIFF
--- a/fanuc_cr35ia_support/launch/load_cr35ia.launch
+++ b/fanuc_cr35ia_support/launch/load_cr35ia.launch
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <launch>
-  <param name="robot_description" command="$(find xacro)/xacro '$(find fanuc_cr35ia_support)/urdf/cr35ia.xacro'" />
+  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find fanuc_cr35ia_support)/urdf/cr35ia.xacro'" />
 </launch>

--- a/fanuc_lrmate200ib_support/launch/load_lrmate200ib.launch
+++ b/fanuc_lrmate200ib_support/launch/load_lrmate200ib.launch
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <launch>
-  <param name="robot_description" command="$(find xacro)/xacro '$(find fanuc_lrmate200ib_support)/urdf/lrmate200ib.xacro'" />
+  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find fanuc_lrmate200ib_support)/urdf/lrmate200ib.xacro'" />
 </launch>

--- a/fanuc_lrmate200ib_support/launch/load_lrmate200ib3l.launch
+++ b/fanuc_lrmate200ib_support/launch/load_lrmate200ib3l.launch
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <launch>
-  <param name="robot_description" command="$(find xacro)/xacro '$(find fanuc_lrmate200ib_support)/urdf/lrmate200ib3l.xacro'" />
+  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find fanuc_lrmate200ib_support)/urdf/lrmate200ib3l.xacro'" />
 </launch>

--- a/fanuc_lrmate200id_support/launch/load_lrmate200id.launch
+++ b/fanuc_lrmate200id_support/launch/load_lrmate200id.launch
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <launch>
-  <param name="robot_description" command="$(find xacro)/xacro '$(find fanuc_lrmate200id_support)/urdf/lrmate200id.xacro'" />
+  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find fanuc_lrmate200id_support)/urdf/lrmate200id.xacro'" />
 </launch>

--- a/fanuc_m6ib_support/launch/load_m6ib.launch
+++ b/fanuc_m6ib_support/launch/load_m6ib.launch
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <launch>
-  <param name="robot_description" command="$(find xacro)/xacro '$(find fanuc_m6ib_support)/urdf/m6ib.xacro'" />
+  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find fanuc_m6ib_support)/urdf/m6ib.xacro'" />
 </launch>

--- a/fanuc_m710ic_support/launch/load_m710ic50.launch
+++ b/fanuc_m710ic_support/launch/load_m710ic50.launch
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <launch>
-  <param name="robot_description" command="$(find xacro)/xacro '$(find fanuc_m710ic_support)/urdf/m710ic50.xacro'" />
+  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find fanuc_m710ic_support)/urdf/m710ic50.xacro'" />
 </launch>

--- a/fanuc_m900ia_support/launch/load_m900ia260l.launch
+++ b/fanuc_m900ia_support/launch/load_m900ia260l.launch
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <launch>
-  <param name="robot_description" command="$(find xacro)/xacro '$(find fanuc_m900ia_support)/urdf/m900ia260l.xacro'" />
+  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find fanuc_m900ia_support)/urdf/m900ia260l.xacro'" />
 </launch>

--- a/fanuc_m900ib_support/launch/load_m900ib700.launch
+++ b/fanuc_m900ib_support/launch/load_m900ib700.launch
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <launch>
-  <param name="robot_description" command="$(find xacro)/xacro '$(find fanuc_m900ib_support)/urdf/m900ib700.xacro'" />
+  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find fanuc_m900ib_support)/urdf/m900ib700.xacro'" />
 </launch>

--- a/fanuc_r1000ia_support/launch/load_r1000ia80f.launch
+++ b/fanuc_r1000ia_support/launch/load_r1000ia80f.launch
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <launch>
-  <param name="robot_description" command="$(find xacro)/xacro '$(find fanuc_r1000ia_support)/urdf/r1000ia80f.xacro'" />
+  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find fanuc_r1000ia_support)/urdf/r1000ia80f.xacro'" />
 </launch>


### PR DESCRIPTION
Newer versions of xacro support this by default, so start using this already.
Fully compatible with Indigo, as the --inorder argument triggers loading Jade+ xacro on Indigo.

Same as https://github.com/ros-industrial/fanuc/pull/201

```xml
xacro: Traditional processing is deprecated. Switch to --inorder processing!
To check for compatibility of your document, use option --check-order.
For more infos, see http://wiki.ros.org/xacro#Processing_Order
```